### PR TITLE
Eliminación directa

### DIFF
--- a/plugins/_antilink.js
+++ b/plugins/_antilink.js
@@ -7,8 +7,6 @@ handler.before = async function (m, { user, isBotAdmin, isAdmin }) {
   let isGroupLink = linkRegex.exec(m.text)
 
   if (chat.antiLink && isGroupLink) {
-    await m.reply(`*「❗️ANTI LINKS❗️」*\n*Eso no se hace 🤨, ${await this.getName(m.sender)} ¡No respetas las reglas!*`)
-    await m.reply(`*Fuera!!*`)
     if (isAdmin) return m.reply('*Que basado/a eres Admin, no puedo eliminarte 😐*') 
     if (!isBotAdmin) return m.reply('*El Bot no es admin, no puede eliminar 😅*')
     let linkGC = ('https://chat.whatsapp.com/' + await this.groupInviteCode(m.chat))


### PR DESCRIPTION
Propongo que el bot elimine directamente al spamer sin que el bot diga algo antes, así será más rápido y el spamer tendrá menos tiempo para seguir poniendo links o salir del grupo para volver después y hacer lo mismo